### PR TITLE
profile: Fix contribution guidelines link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,6 +8,6 @@ We also have an [infosite](https://info.leaderboards.gg) that gives more details
 
 * [Frontend](https://github.com/leaderboardsgg/leaderboard-site) - Nuxt
 * [Backend](https://github.com/leaderboardsgg/leaderboard-backend) - .NET
-    * Read the readme and the [contribution guidelines](github.com/leaderboardsgg/leaderboard-backend/wiki#for-contributing) to get started
+    * Read the readme and the [contribution guidelines](https://github.com/leaderboardsgg/leaderboard-backend/wiki#for-contributing) to get started
 * [Infosite](https://github.com/leaderboardsgg/infosite) - Nuxt
 * [Admin site](https://github.com/leaderboardsgg/leaderboard-admin) - Vue


### PR DESCRIPTION
For the link to go to the correct place it must be an absolute link. To
do so the "https://" prefix is added.

If this is missing the link will take the user to
> https://github.com/leaderboardsgg/.github/blob/main/profile/github.com/leaderboardsgg/leaderboard-backend/wiki#for-contributing
As opposed to
> https://github.com/leaderboardsgg/leaderboard-backend/wiki#for-contributing
